### PR TITLE
use X2go by default instead of Xpra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN cd /root \
   && ./install-vscode.sh \
   && cp install-vscode-*.sh /home/vscode/ \
   && cp start-xpra.sh /home/vscode/ \
+  && cp start-ssh.sh /home/vscode/ \
   && chown vscode:vscode /home/vscode/*.sh \
   && su - vscode -c /home/vscode/install-vscode-RustyCode.sh \
   && su - vscode -c /home/vscode/install-vscode-debug.sh
 
 WORKDIR /root
-CMD service ssh start
+CMD su - vscode -c /home/vscode/start-ssh.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY root /root
 
 RUN cd /root \
   && ./install-user.sh \
-  && ./install-xpra.sh \
+  && ./install-x2go.sh \
   && ./install-vscode.sh \
   && cp install-vscode-*.sh /home/vscode/ \
   && cp start-xpra.sh /home/vscode/ \
@@ -18,4 +18,4 @@ RUN cd /root \
   && su - vscode -c /home/vscode/install-vscode-debug.sh
 
 WORKDIR /root
-CMD su - vscode
+CMD service ssh start

--- a/root/install-chrome.sh
+++ b/root/install-chrome.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# https://www.google.com/linuxrepositories/
+# https://wiki.debian.org/UnofficialRepositories
+curl https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+apt-get update
+apt-get install -y google-chrome-stable

--- a/root/install-firefox.sh
+++ b/root/install-firefox.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# http://mozilla.debian.net/
+curl http://mozilla.debian.net/archive.asc | apt-key add -
+echo "deb http://mozilla.debian.net/ jessie-backports firefox-release" > /etc/apt/sources.list.d/mozilla.list
+apt-get update
+apt-get install -y firefox

--- a/root/install-user.sh
+++ b/root/install-user.sh
@@ -2,7 +2,7 @@
 export DEBIAN_FRONTEND=noninteractive
 apt-get update \
 && apt-get install -y --no-install-recommends apt-utils \
-&& apt-get install -y --no-install-recommends curl unzip sudo \
+&& apt-get install -y --no-install-recommends curl unzip sudo nano \
 && useradd -m vscode -s /bin/bash \
 && adduser vscode sudo \
 && echo 'vscode ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/root/install-vscode.sh
+++ b/root/install-vscode.sh
@@ -9,4 +9,5 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y curl unzip \
   libgtk2.0-0 libgconf-2-4 libnss3 libasound2 libxtst6 libnotify4 \
 && curl -o vscode-amd64.deb -L https://vscode-update.azurewebsites.net/latest/linux-deb-x64/stable \
-&& dpkg -i vscode-amd64.deb
+&& dpkg -i vscode-amd64.deb \
+&& rm vscode-amd64.deb

--- a/root/install-x2go.sh
+++ b/root/install-x2go.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# installs x2go, lxde, & lightdm for debian 8 jessie
+# http://wiki.x2go.org/doku.php/doc:installation:x2goserver
+# adjust lixcb.so.1 so VSCode launches http://stackoverflow.com/a/37695964/23059
+export DEBIAN_FRONTEND=noninteractive
+apt-key adv --recv-keys --keyserver keys.gnupg.net E1F958385BFE2B6E
+echo "deb http://packages.x2go.org/debian jessie main" > /etc/apt/sources.list.d/x2go.list
+apt-get update
+apt-get install -y x2go-keyring
+apt-get update
+apt-get install -y x2goserver x2goserver-xsession
+apt-get install -y --no-install-recommends lxde-core
+apt-get install -y lightdm
+sed -i 's/BIG-REQUESTS/_IG-REQUESTS/' /usr/lib/x86_64-linux-gnu/libxcb.so.1

--- a/root/install-x2go.sh
+++ b/root/install-x2go.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # installs x2go, lxde, & lightdm for debian 8 jessie
 # http://wiki.x2go.org/doku.php/doc:installation:x2goserver
-# adjust lixcb.so.1 so VSCode launches http://stackoverflow.com/a/37695964/23059
 export DEBIAN_FRONTEND=noninteractive
 apt-key adv --recv-keys --keyserver keys.gnupg.net E1F958385BFE2B6E
 echo "deb http://packages.x2go.org/debian jessie main" > /etc/apt/sources.list.d/x2go.list
@@ -9,6 +8,11 @@ apt-get update
 apt-get install -y x2go-keyring
 apt-get update
 apt-get install -y x2goserver x2goserver-xsession
-apt-get install -y --no-install-recommends lxde-core
-apt-get install -y lightdm
+apt-get install -y --no-install-recommends lxde-core xdg-utils
+apt-get install -y lightdm lxterminal dbus-x11
+
+# adjust lixcb.so.1 so VSCode launches http://stackoverflow.com/a/37695964/23059
 sed -i 's/BIG-REQUESTS/_IG-REQUESTS/' /usr/lib/x86_64-linux-gnu/libxcb.so.1
+
+# disable lxpolkit on login which throws 'No session for pid <pid>' error
+sed -i '/\[Session\]/a polkit/command=' /etc/xdg/lxsession/LXDE/desktop.conf

--- a/root/start-ssh.sh
+++ b/root/start-ssh.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Create ssh "client" key
+# http://stackoverflow.com/a/20977657
+
+if [ ! -f ~/.ssh/id_rsa ]; then
+    ssh-keygen -q -t rsa -N "" -f ~/.ssh/id_rsa
+    cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+fi
+
+echo "Use this private key to log in:"
+cat ~/.ssh/id_rsa 
+
+# Start sshd
+sudo mkdir -p /var/run/sshd
+sudo /usr/sbin/sshd -D

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+docker run --name=vscode -itd -p 2222:22 --security-opt seccomp=unconfined ctaggart/rusty-vscode
+sleep 3
+docker logs vscode


### PR DESCRIPTION
I've found it easier to explain how to use X2go to users familiar with remote desktop production like Microsoft RDP.

Credit to docker-x2go for showing that this works.
https://github.com/tatsuya6502/docker-x2go
